### PR TITLE
Svg support

### DIFF
--- a/js/src/main/scala/com/raquo/dombuilder/jsdom/domapi/JsElementApi.scala
+++ b/js/src/main/scala/com/raquo/dombuilder/jsdom/domapi/JsElementApi.scala
@@ -14,7 +14,11 @@ trait JsElementApi[N] extends ElementApi[N, dom.Element, dom.Node] {
   override def createNode[Ref <: dom.Element](element: N with Element[N, Ref, dom.Node]): Ref = {
     dom.document.createElement(element.tagName).asInstanceOf[Ref]
   }
-
+  
+  override def createNodeNS[Ref <: dom.Element](element: N with Element[N, Ref, dom.Node],ns:String): Ref = {
+    dom.document.createElementNS(ns,element.tagName).asInstanceOf[Ref]
+  }
+  
   override def setAttribute[V](element: BaseElement, attr: Attr[V], value: V): Unit = {
     val domValue = attr.codec.encode(value)
     if (domValue == null) { // End users should use `removeAttribute` instead. This is to support boolean attributes.


### PR DESCRIPTION
- [x]  add document.createElementNS ( https://github.com/raquo/scala-dom-builder/pull/3/commits/2354b477065a20010ad9897886ffddf589e359e9 )
- [ ]  add some svg example for test

what else needs to be done?

 https://github.com/raquo/scala-dom-types/issues/20 